### PR TITLE
bulid: use npm to run scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build-shop": "VITE_APP=shop vite build",
     "build-submit": "VITE_APP=submit vite build",
     "build-review": "VITE_APP=review vite build",
-    "build": "pnpm build-shop && pnpm build-submit && pnpm build-review && ./create_xdc.sh",
+    "build": "npm run build-shop && npm run build-submit && npm run build-review && ./create_xdc.sh",
     "serve": "vite preview"
   },
   "license": "MIT",


### PR DESCRIPTION
There is no difference between using npm and pnpm to run scripts. The only significant difference is between `npm install` and `pnpm install`, because they use different lockfiles.