### PR TITLE
fix: replace Object.hasOwn() with Object.prototype.hasOwnProperty.call()

### DIFF
--- a/frontend/src/entry-points/review.tsx
+++ b/frontend/src/entry-points/review.tsx
@@ -23,7 +23,7 @@ interface ReviewStateProps {
 }
 
 function isReviewResponse(p: any): p is ReviewResponse {
-  return Object.hasOwn(p, 'okay')
+  return Object.prototype.hasOwnProperty.call(p, 'okay')
 }
 
 const ReviewState: Component<ReviewStateProps> = (props) => {

--- a/frontend/src/entry-points/shop.tsx
+++ b/frontend/src/entry-points/shop.tsx
@@ -34,11 +34,11 @@ function isEmpty(obj: any) {
 }
 
 function isDownloadResponse(p: any): p is DownloadResponse {
-  return Object.hasOwn(p, 'okay')
+  return Object.prototype.hasOwnProperty.call(p, 'okay')
 }
 
 function isUpdateResponse(p: any): p is UpdateResponse {
-  return Object.hasOwn(p, 'app_infos')
+  return Object.prototype.hasOwnProperty.call(p, 'app_infos')
 }
 
 function AppInfoModal(item: AppInfoWithState, onDownload: () => void) {

--- a/frontend/src/entry-points/submit.tsx
+++ b/frontend/src/entry-points/submit.tsx
@@ -14,7 +14,7 @@ import type { SubmitResponse } from '../bindings/SubmitResponse'
 import { isAppInfo } from '../utils'
 
 function isSubmitResponse(p: any): p is SubmitResponse {
-  return Object.hasOwn(p, 'okay')
+  return Object.prototype.hasOwnProperty.call(p, 'okay')
 }
 
 const Submit: Component = () => {
@@ -23,7 +23,7 @@ const Submit: Component = () => {
   const is_appdata_complete = createMemo(() => Object.values(appInfo()).reduce((init, v) => init && !(v === undefined || v === null || v === ''), true))
   let lastAppinfo: AppInfo = {} as AppInfo
   const is_different = createMemo(() => JSON.stringify(appInfo()) !== JSON.stringify(lastAppinfo))
-  const has_loaded = createMemo(() => Object.hasOwn(appInfo(), 'version'))
+  const has_loaded = createMemo(() => Object.prototype.hasOwnProperty.call(appInfo(), 'version'))
   const [showButton, setShowButton] = useStorage('show_submit', true)
   const [success, setSuccess] = createSignal<undefined | boolean>(undefined)
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,5 +1,5 @@
 import type { AppInfo } from './bindings/AppInfo'
 
 export function isAppInfo(p: any): p is AppInfo {
-  return Object.hasOwn(p, 'version')
+  return Object.prototype.hasOwnProperty.call(p, 'version')
 }


### PR DESCRIPTION
`Object.hasOwn()` is only supported since Chrome 93 and we target at least Chrome 74.

Closes #42