### PR TITLE
fix(scripts/dist.sh): do not create bot-data/VERSION

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -20,7 +20,6 @@ cd "$SRC"
 cargo build --release
 
 cp target/release/xdcstore "$DESTDIR/xdcstore"
-git describe --always >"$DESTDIR/bot-data/VERSION"
 
 mkdir -p "$SRC/dist"
 OUT="$SRC/dist/xdcstore.tar.gz"


### PR DESCRIPTION
This file is not required at runtime
since f5e61ab80304c50338c88e80aa54913ad7079271