### PR TITLE
enable eruda for store.xdc

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "eruda": "^3.0.0",
     "@antfu/eslint-config": "^0.39.3",
     "@unocss/eslint-config": "^0.52.2",
     "eslint": "^8.42.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,6 +46,9 @@ devDependencies:
   '@unocss/eslint-config':
     specifier: ^0.52.2
     version: 0.52.2(eslint@8.42.0)(typescript@5.1.3)
+  eruda:
+    specifier: ^3.0.0
+    version: 3.0.0
   eslint:
     specifier: ^8.42.0
     version: 8.42.0
@@ -1759,6 +1762,10 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
+
+  /eruda@3.0.0:
+    resolution: {integrity: sha512-6L8A8aBHOQv0rqeBlNdJEl/hl6OAdLVRtJlVmBIlIJ6Fe1a92HFXO58jHLC0vFyuKV0deTjYjRaWwLo9lJ9K9A==}
     dev: true
 
   /es-abstract@1.21.2:

--- a/frontend/shop.html
+++ b/frontend/shop.html
@@ -15,12 +15,6 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <script src="/src/entry-points/shop.tsx" type="module"></script>
-
-  <!-- Uncomment to include developer tools to debug inside Delta Chat -->
-  <script type="module">
-   import init from 'eruda'
-   init.init();
-  </script>
 </body>
 
 </html>

--- a/frontend/shop.html
+++ b/frontend/shop.html
@@ -15,6 +15,12 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <script src="/src/entry-points/shop.tsx" type="module"></script>
+
+  <!-- Uncomment to include developer tools to debug inside Delta Chat -->
+  <script type="module">
+   import init from 'eruda'
+   init.init();
+  </script>
 </body>
 
 </html>

--- a/frontend/src/decs.d.ts
+++ b/frontend/src/decs.d.ts
@@ -1,0 +1,1 @@
+declare module 'eruda';

--- a/frontend/src/entry-points/review.tsx
+++ b/frontend/src/entry-points/review.tsx
@@ -11,6 +11,12 @@ import '@unocss/reset/tailwind.css'
 import { isAppInfo } from '../utils'
 import type { ReviewResponse } from '../bindings/ReviewResponse'
 import type { ReviewRequest } from '../bindings/ReviewRequest'
+import eruda from 'eruda'
+
+if (import.meta.env.DEV) {
+  console.log('Starting eruda')
+  eruda.init()
+}
 
 interface TestStatus {
   android: boolean


### PR DESCRIPTION
would be nice to inject the script tag adding eruda only selectively depending on a flag ( for debug or release) in the build scripts in package.json 

if some web dev can take over this PR and do that, otherwise we can enable it for now and disable it later