### PR TITLE
fix: link xdcstore binary statically against musl libc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - run: |
+          sudo apt install musl-tools
+          rustup target add x86_64-unknown-linux-musl
+
       - name: Cache Rust builds
         uses: swatinem/rust-cache@v2
 

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -17,9 +17,10 @@ npm run build
 
 # Build the backend.
 cd "$SRC"
-cargo build --release
 
-cp target/release/xdcstore "$DESTDIR/xdcstore"
+cargo build --target x86_64-unknown-linux-musl --release
+
+cp target/x86_64-unknown-linux-musl/release/xdcstore "$DESTDIR/xdcstore"
 
 mkdir -p "$SRC/dist"
 OUT="$SRC/dist/xdcstore.tar.gz"


### PR DESCRIPTION
Fixes #107 