### PR TITLE
feat: store configuration in .config/xdcstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1272,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2931,6 +2952,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -5539,6 +5566,7 @@ dependencies = [
  "build_script_file_gen",
  "clap",
  "deltachat",
+ "directories",
  "env_logger",
  "futures",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ qr2term = "0.3.1"
 sqlx = { git = "https://github.com/launchbadge/sqlx.git", features = [ "runtime-tokio", "migrate", "sqlite" ] }
 futures= "*"
 build_script_file_gen = "0.6.1"
+directories = "5.0.0"
 
 [build-dependencies]
 build_script_file_gen = "0.6.1"

--- a/frontend/create_xdc.sh
+++ b/frontend/create_xdc.sh
@@ -2,7 +2,7 @@
 
 : "${DESTDIR:=$PWD/..}"
 
-DESTDIR="$DESTDIR/bot-data"
+DESTDIR="$DESTDIR/assets"
 
 mkdir -p "$DESTDIR"
 cd dist

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ use crate::{
     bot::State,
     db,
     request_handlers::{shop::ShopResponse, AppInfo, WexbdcManifest},
-    REVIEW_HELPER_XDC, SHOP_XDC, SUBMIT_HELPER_XDC,
+    REVIEW_HELPER_XDC, STORE_XDC, SUBMIT_HELPER_XDC,
 };
 
 pub async fn configure_from_env(ctx: &Context) -> Result<()> {
@@ -166,7 +166,7 @@ pub enum Webxdc {
 impl Webxdc {
     pub fn get_str_path(&self) -> &'static str {
         match self {
-            Webxdc::Shop => SHOP_XDC,
+            Webxdc::Shop => STORE_XDC,
             Webxdc::Submit => SUBMIT_HELPER_XDC,
             Webxdc::Review => REVIEW_HELPER_XDC,
         }


### PR DESCRIPTION
Frontend xdcs are now stored in `./assets/`, assets directory is built once and is not changed. Moving this to something like `/usr/share/xdcstore` or building into the binary is out of scope for this PR.

Both databases (bot database and deltachat core database), blob storage and imported XDCs folder `xdcs/` go to `~/.config/xdcstore`. Removing `~/.config/xdcstore` resets the bot.

Closes #93