### PR TITLE
Add version display in store.xdc

### DIFF
--- a/frontend/src/entry-points/shop.tsx
+++ b/frontend/src/entry-points/shop.tsx
@@ -160,6 +160,7 @@ const Shop: Component = () => {
   }))
   const [isUpdating, setIsUpdating] = createSignal(false)
   const [search, setSearch] = createSignal('')
+  const [showCommit, setShowCommit] = createSignal(false)
 
   const past_time = Math.abs(new Date().getTime() - lastUpdate().getTime()) / 1000
   if (appInfo === undefined || (past_time > 60 * 60)) {
@@ -259,8 +260,13 @@ const Shop: Component = () => {
     <OutdatedView critical={updateNeeded()} updated_received={updateReceived()}>
       <div class="c-grid p-3">
         <div class="min-width">
-          <div class="flex justify-between gap-2">
-            <h1 class="text-2xl font-bold">Webxdc Appstore</h1>
+          <div class="flex items-center justify-between gap-2">
+            <div>
+              <h1 class="flex-shrink text-2xl font-bold" onclick={() => setShowCommit(!showCommit())}>
+                Webxdc Appstore
+              </h1>
+              {showCommit() && <p class="whitespace-nowrap text-sm unimportant"> @ {import.meta.env.VITE_COMMIT} </p>}
+            </div>
             <div class="rounded-xl bg-gray-100 p-2 unimportant text-gray-500">
               <Show when={isUpdating()} fallback={
                 <button class="flex items-center gap-2" onclick={handleUpdate}>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,30 +1,33 @@
-import { defineConfig, loadEnv } from 'vite';
-import solidPlugin from 'vite-plugin-solid';
-import unocssPlugin from "unocss/vite"
-//@ts-ignore
-import { resolve } from 'path'
+import { resolve } from 'node:path'
+import { execSync } from 'child_process'
+import { defineConfig, loadEnv } from 'vite'
+import solidPlugin from 'vite-plugin-solid'
+import unocssPlugin from 'unocss/vite'
+
+// @ts-expect-error
 
 export default defineConfig(({ mode }) => {
-  //@ts-ignore
+  // @ts-expect-error
   const env = loadEnv(mode, process.cwd(), '')
-  const app_name = env.VITE_APP || 'shop'
+  const app_name = env.VITE_APP
+  process.env.VITE_COMMIT = String(execSync('git describe --always'))
 
   return {
     plugins: [solidPlugin(), unocssPlugin()],
     build: {
-      target: ["es2020", "edge88", "firefox78", "chrome74", "safari14"],
+      target: ['es2020', 'edge88', 'firefox78', 'chrome74', 'safari14'],
       rollupOptions: {
         input: {
-          //@ts-ignore
+          // @ts-expect-error
           shop: resolve(__dirname, `./${app_name}.html`),
         },
         output: {
-          dir: 'dist/' + app_name
-        }
+          dir: `dist/${app_name}`,
+        },
       },
     },
     server: {
       port: 3000,
-    }
+    },
   }
-});
+})


### PR DESCRIPTION
When clicking on the name this version field is displayed:

![image](https://github.com/webxdc/store/assets/39526136/f3312384-2e8d-4dd6-848b-8fc7dc4ccc28)

This way the view is not cluttered with an omnipresent version display.
The version is the commit the package was bundled with which is as explicit as possible :)

close #118 