### PR TITLE
ci: check types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Build the frontend
         run: |
           npx pnpm install
+          npx pnpm run check-types
           npx pnpm run lint
         working-directory: frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && ./create_xdc.sh",
     "serve": "vite preview",
     "lint": "eslint . --ext .tsx",
+    "check-types": "tsc --noEmit --skipLibCheck",
     "test": "vitest run"
   },
   "license": "MIT",


### PR DESCRIPTION
I have noticed that CI does not cache TypeScript errors I introduce.

Vite documentation at https://vitejs.dev/guide/features.html says
> Note that Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process.
> ...
> For production builds, you can run `tsc --noEmit` in addition to Vite's build command.

So I added a `check-types` script that runs `tsc --noEmit` and run it in CI.