### PR TITLE
Remove web fonts

### DIFF
--- a/frontend/uno.config.ts
+++ b/frontend/uno.config.ts
@@ -5,7 +5,6 @@ import {
   presetIcons,
   presetTypography,
   presetUno,
-  presetWebFonts,
   transformerDirectives,
   transformerVariantGroup,
 } from 'unocss'
@@ -25,13 +24,6 @@ export default defineConfig({
       warn: true,
     }),
     presetTypography(),
-    presetWebFonts({
-      fonts: {
-        sans: 'DM Sans',
-        serif: 'DM Serif Display',
-        mono: 'DM Mono',
-      },
-    }),
   ],
   extractors: [
     extractorSplit,


### PR DESCRIPTION
Beforehand we used https://unocss.dev/presets/web-fonts, but even without the web fonts it still looks good IMO, so let's remove them to close #170