### PR TITLE
test: run pytest with -v by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py3
 
 [testenv]
-commands = pytest {posargs}
+commands = pytest -v {posargs}
 passenv =
     DCC_NEW_TMP_EMAIL
 deps =


### PR DESCRIPTION
This way pytest prints the reason when it skips the test, e.g. when DCC_NEW_TMP_EMAIL is not set.