### PR TITLE
fix: remove hypen in 'Source-code'

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -86,7 +86,7 @@ function AppInfoModal(item: AppInfoWithState, onDownload: () => void, onForward:
                 <button class="text-sm text-blue-500" onClick={onRemove}>Remove</button>
               </Show>
             </div>
-            <p class="break-all text-sm text-gray-600"><span class="font-bold"> Source-code: </span>{item.source_code_url}</p>
+            <p class="break-all text-sm text-gray-600"><span class="font-bold"> Source: </span>{item.source_code_url}</p>
           </div>
         </div>
       </Show>


### PR DESCRIPTION
the correct spelling would be 'Source code',
however, just 'Source' is shorter here
and maybe even more fitting
(we know for sure, it is the source of the xdc-release, which may be minified, webassembly and whatnot,
but we did not check the source code)

