### PR TITLE
fix: update app state even if appInfo store is not populated yet

### DIFF
--- a/frontend/src/db/store_db.ts
+++ b/frontend/src/db/store_db.ts
@@ -1,5 +1,5 @@
 import type { AppInfo } from '../bindings/AppInfo'
-import type { AppInfoWithState } from '../types'
+import type { AppState, AppInfoWithState } from '../types'
 import type { XDCFile } from '../webxdc'
 
 export class AppInfoDB {
@@ -68,14 +68,20 @@ export class AppInfoDB {
     })
   }
 
-  async update(data: AppInfoWithState): Promise<void> {
+  // Set the state of the app.
+  async updateState(app_id: string, state: AppState): Promise<void> {
     const db = await this.open()
     return new Promise((resolve, reject) => {
       const transaction = db.transaction('appInfo', 'readwrite')
       transaction.onerror = () => reject(transaction.error)
       const store = transaction.objectStore('appInfo')
-      const request = store.put(data)
-      request.onsuccess = () => resolve()
+      const request = store.get(app_id)
+      request.onsuccess = () => {
+          const appInfo = request.result
+          appInfo.state = state
+          const putRequest = store.put(appInfo)
+          putRequest.onsuccess = () => resolve()
+      }
     })
   }
 

--- a/frontend/src/store-logic.ts
+++ b/frontend/src/store-logic.ts
@@ -92,7 +92,7 @@ export async function updateHandler(
     console.log('Received webxdc')
     const file = { base64: payload.data, name: `${payload.name}.xdc` }
     await db.add_webxdc(file, payload.app_id)
-    await db.update({ ...appInfo[payload.app_id], state: AppState.Received })
+    await db.updateState(payload.app_id, AppState.Received)
     setAppInfo(payload.app_id, 'state', AppState.Received)
   }
   else if (isDownloadResponseError(payload)) {


### PR DESCRIPTION
If the application has just been launched,
appStore may be not populated yet
as it requires reading the whole `appInfo` object store and takes time.

Instead of relying on `appInfo` store,
read the info of the application in the same transaction.

Fixes #203.