### PR TITLE
feat: set default log level to "info"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ const VERSION: &str = include_file_str!("VERSION");
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let cli = BotCli::parse();
 
     match &cli.action {


### PR DESCRIPTION
This way there are at least some logs shown when you run `cargo run start` without setting the `RUST_LOG` environment variable.