### PR TITLE
fix: show tip on botless frontend

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -167,7 +167,7 @@ const Store: Component = () => {
 
     if (import.meta.env.DEV) {
       setAppInfo(mock)
-      // setlastSerial(1)
+      setlastSerial(1)
     }
   })
 
@@ -235,38 +235,36 @@ const Store: Component = () => {
               </button>
             </div>
             <hr />
-            <ul class="w-full flex flex-grow flex-col gap-1 p-2">
-              <Show when={!(lastSerial() === 0)} fallback={
-                <div class="text-center unimportant">
-                  <p class="mb-2">
-                    This Webxdc Store is not connected to a Bot to get apps from.
-                  </p>
-                  <p>
-                    To get a working Webxdc store, you need to send "Hi" to a store address, for example
-                    xstore@testrun.org, which is a community hosted instance with some curated apps.
-                  </p>
-                </div>
-              }>
+            <Show when={!(lastSerial() === 0)} fallback={<div class="text-center unimportant mt-5">
+              <p class="mb-2">
+                This Webxdc Store is not connected to a Bot to get apps from.
+              </p>
+              <p>
+                To get a working Webxdc store, you need to send "Hi" to a store address, for example
+                xstore@testrun.org, which is a community hosted instance with some curated apps.
+              </p>
+            </div>}>
+              <ul class="w-full flex flex-grow flex-col gap-1 p-2">
                 <AppList
                   items={Object.values(appInfo).sort((a, b) => Number(b.date - a.date))} search_query={query()}
                   onDownload={handleDownload}
                   onForward={handleForward}
                   onRemove={handleRemove}
-                  onDragStart={onDragStart} ></AppList>
-              </Show>
-            </ul>
-            <hr />
-            <div class="flex flex-col flex-wrap justify-center gap-2 py-4 pb-5 xs:flex-row">
-              <button class="font-thin unimportant" onClick={() => setShowCommit(!showCommit())}>
-                Last update: {isUpdating() ? 'Updating..' : `${formatDistanceToNow(lastUpdate())} ago`}
-              </button>
-              <Show when={!isUpdating()}>
-                <span class="hidden unimportant xs:block">-</span>
-                <button class="text-blue-500" onclick={update}>
-                  Update
+                  onDragStart={onDragStart}></AppList>
+              </ul>
+              <hr />
+              <div class="flex flex-col flex-wrap justify-center gap-2 py-4 pb-5 xs:flex-row">
+                <button class="font-thin unimportant" onClick={() => setShowCommit(!showCommit())}>
+                  Last update: {isUpdating() ? 'Updating..' : `${formatDistanceToNow(lastUpdate())} ago`}
                 </button>
-              </Show>
-            </div>
+                <Show when={!isUpdating()}>
+                  <span class="hidden unimportant xs:block">-</span>
+                  <button class="text-blue-500" onclick={update}>
+                    Update
+                  </button>
+                </Show>
+              </div>
+            </Show>
           </div>
         </div >
       </div>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -238,13 +238,13 @@ const Store: Component = () => {
             <ul class="w-full flex flex-grow flex-col gap-1 p-2">
               <Show when={!(lastSerial() === 0)} fallback={
                 <div class="text-center unimportant">
-                  <p >This Webxdc Store
-                    is not connected to a Bot
-                    to get apps from.
+                  <p class="mb-2">
+                    This Webxdc Store is not connected to a Bot to get apps from.
                   </p>
-                  <p >To get a working Webxdc store,
+                  <p>
+                    To get a working Webxdc store,
                     you need to send "Hi" to a store address and use the store app you get back.
-                    If nothing else you may try sending "Hi" to xstore@testrun.org , an experimental
+                    If nothing else works, you may try sending "Hi" to xstore@testrun.org, an experimental
                     community deployment offering some curated apps.
                   </p>
                 </div>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -125,7 +125,8 @@ const AppList: Component<AppListProps> = (props) => {
   })
 
   return (
-    <Show when={filtered_items().length !== 0} fallback={<p class="text-center unimportant">No results for "{props.search_query}"</p>}>
+    <Show when={filtered_items().length !== 0} fallback={
+      <Show when={props.search_query.length > 0}><p class="text-center unimportant">No results for "{props.search_query}"</p></Show>}>
       <For each={filtered_items() || props.items}>
         {(item, index) => (
           <>
@@ -166,7 +167,7 @@ const Store: Component = () => {
 
     if (import.meta.env.DEV) {
       setAppInfo(mock)
-      setlastSerial(1)
+      // setlastSerial(1)
     }
   })
 
@@ -236,7 +237,16 @@ const Store: Component = () => {
             <hr />
             <ul class="w-full flex flex-grow flex-col gap-1 p-2">
               <Show when={!(lastSerial() === 0)} fallback={
-                <p class="text-center unimportant">Loading store..</p>
+                <div class="text-center unimportant">
+                  <p >This Webxdc Store
+                    is not connected to a Bot
+                    to get apps from.
+                  </p>
+                  <p >To get a working Webxdc Store,
+                    please send "Hi" to
+                    appbot@testrun.org
+                  </p>
+                </div>
               }>
                 <AppList
                   items={Object.values(appInfo).sort((a, b) => Number(b.date - a.date))} search_query={query()}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -242,9 +242,10 @@ const Store: Component = () => {
                     is not connected to a Bot
                     to get apps from.
                   </p>
-                  <p >To get a working Webxdc Store,
-                    please send "Hi" to
-                    appbot@testrun.org
+                  <p >To get a working Webxdc store,
+                    you need to send "Hi" to a store address and use the store app you get back.  
+                    If nothing else you may try sending "Hi" to xstore@testrun.org , an experimental 
+                    community deployment offering some curated apps. 
                   </p>
                 </div>
               }>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -243,9 +243,9 @@ const Store: Component = () => {
                     to get apps from.
                   </p>
                   <p >To get a working Webxdc store,
-                    you need to send "Hi" to a store address and use the store app you get back.  
-                    If nothing else you may try sending "Hi" to xstore@testrun.org , an experimental 
-                    community deployment offering some curated apps. 
+                    you need to send "Hi" to a store address and use the store app you get back.
+                    If nothing else you may try sending "Hi" to xstore@testrun.org , an experimental
+                    community deployment offering some curated apps.
                   </p>
                 </div>
               }>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -242,10 +242,8 @@ const Store: Component = () => {
                     This Webxdc Store is not connected to a Bot to get apps from.
                   </p>
                   <p>
-                    To get a working Webxdc store,
-                    you need to send "Hi" to a store address and use the store app you get back.
-                    If nothing else works, you may try sending "Hi" to xstore@testrun.org, an experimental
-                    community deployment offering some curated apps.
+                    To get a working Webxdc store, you need to send "Hi" to a store address, for example
+                    xstore@testrun.org, which is a community hosted instance with some curated apps.
                   </p>
                 </div>
               }>

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -172,7 +172,7 @@ impl Bot {
             }
         });
         self.dc_ctx.start_io().await;
-        info!("successfully started bot! 🥳");
+        info!("Successfully started bot! 🥳");
     }
 
     /// Handle dc-events.


### PR DESCRIPTION
This PR adds the initial store state to the store message itself so that the first update is there immediately. It also adds a new message to the uninitialized store to help people get it to work when they just forwarded the store.


![Screenshot from 2023-07-30 08-10-19](https://github.com/webxdc/store/assets/39526136/c20e9727-5149-4ed5-a4c9-d94a331e3876)

close #202