### PR TITLE
docs: add documentation comments

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,4 +1,5 @@
-//! Entry for the bot code
+//! Entry for the bot code.
+
 use anyhow::{Context as _, Result};
 use deltachat::{
     chat::{self, ChatId},
@@ -26,22 +27,34 @@ use crate::{
     INVITE_QR, VERSION,
 };
 
+/// Bot configuration.
 #[derive(FromRow, Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct BotConfig {
+    /// QR code for the contact setup.
     pub invite_qr: String,
+
+    /// Serial number incremented each time an application index is changed.
     pub serial: i32,
 }
 
-/// Github Bot state
+/// Bot state.
 pub struct State {
+    /// SQLite connection pool.
     pub db: SqlitePool,
+
+    /// Bot configuration.
     pub config: BotConfig,
+
+    /// `tag_name` field from the `manifest.toml` of the `store.xdc`.
     pub store_tag_name: String,
 }
 
-/// Github Bot
+/// Store bot.
 pub struct Bot {
+    /// Delta Chat account.
     dc_ctx: Context,
+
+    /// Reference to the bot state.
     state: Arc<State>,
 }
 
@@ -266,6 +279,7 @@ impl Bot {
         Ok(())
     }
 
+    /// Retrieves a database connection from the pool.
     pub async fn get_db_connection(&self) -> sqlx::Result<PoolConnection<Sqlite>> {
         self.state.db.acquire().await
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,17 @@
+//! Command line interface.
+
 use clap::{Parser, Subcommand};
 
+/// Command line argument parser.
 #[derive(Parser, Debug)]
 #[command()]
 pub struct BotCli {
+    #[allow(clippy::missing_docs_in_private_items)]
     #[command(subcommand)]
     pub action: BotActions,
 }
 
+/// Command line subcommands.
 #[derive(Subcommand, Debug)]
 pub enum BotActions {
     /// Start the bot.

--- a/src/db.rs
+++ b/src/db.rs
@@ -12,21 +12,44 @@ use itertools::Itertools;
 use sqlx::{migrate::Migrator, Connection, FromRow, Row, SqliteConnection};
 use std::path::PathBuf;
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub static MIGRATOR: Migrator = sqlx::migrate!();
 
 /// Only a intermediate struct because Decode can not (yet) be derived for [AppInfo].
 #[derive(FromRow)]
 pub struct DBAppInfo {
+    #[allow(clippy::missing_docs_in_private_items)]
     pub id: RecordId,
+
+    /// Application ID, e.g. `webxdc-poll`.
     pub app_id: String,
+
+    /// Application name, e.g. `Checklist`.
     pub name: String,
+
+    /// Date as a timestamp in seconds.
     pub date: i64,
+
+    /// Source code URL, e.g. `https://codeberg.org/webxdc/checklist`.
     pub source_code_url: String,
+
+    /// Application icon encoded as a data URL,
+    /// for example `data:image/png;base64,...`.
     pub image: String,
+
+    /// Human-readable application description.
     pub description: String,
+
+    /// Absolute path to the .xdc file.
     pub xdc_blob_path: String,
+
+    /// Application size in bytes.
     pub size: i64,
+
+    /// Release tag, e.g. `v2.2.0`.
     pub tag_name: String,
+
+    /// True if the application has been removed.
     pub removed: bool,
 }
 
@@ -48,8 +71,10 @@ impl From<DBAppInfo> for AppInfo {
     }
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub type RecordId = i32;
 
+/// Stores the bot configuration into the `config` table of the bot database.
 pub async fn set_config(c: &mut SqliteConnection, config: &BotConfig) -> Result<()> {
     sqlx::query("INSERT INTO config (invite_qr, serial) VALUES (?, ?)")
         .bind(&config.invite_qr)
@@ -59,6 +84,7 @@ pub async fn set_config(c: &mut SqliteConnection, config: &BotConfig) -> Result<
     Ok(())
 }
 
+/// Retrieves the bot configuration from the database.
 pub async fn get_config(c: &mut SqliteConnection) -> Result<BotConfig> {
     let res: BotConfig = sqlx::query_as::<_, BotConfig>("SELECT invite_qr, serial FROM config")
         .fetch_one(c)
@@ -265,7 +291,7 @@ pub async fn set_store_tag_name(
     Ok(())
 }
 
-/// Gets the webxdc tag_name for some sent webxdc.
+/// Returns the webxdc `tag_name` for some previously sent `store.xdc` instance.
 pub async fn get_store_tag_name(c: &mut SqliteConnection, msg: MsgId) -> sqlx::Result<String> {
     sqlx::query("SELECT * FROM webxdc_tag_names WHERE msg_id = ?")
         .bind(msg.to_u32())

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,3 +1,5 @@
+//! Importing applications into the bot.
+
 use anyhow::{bail, Context as _, Result};
 use async_zip::tokio::read::fs::ZipFileReader;
 use base64::encode;
@@ -17,6 +19,7 @@ use crate::{
     utils::{maybe_upgrade_xdc, read_vec, AddType},
 };
 
+/// Structure of the `manifest.toml` stored in .xdc files.
 #[derive(Deserialize, Debug)]
 pub struct WebxdcManifest {
     /// Webxdc application identifier.
@@ -41,6 +44,7 @@ pub struct WebxdcManifest {
     pub cache_relname: PathBuf,
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub async fn import_many(
     path: &Path,
     xdcs_path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,12 @@
-#![warn(clippy::all, clippy::indexing_slicing, clippy::unwrap_used)]
+//! Store bot.
+
+#![warn(
+    clippy::all,
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    clippy::missing_docs_in_private_items,
+    missing_docs
+)]
 mod bot;
 mod cli;
 mod db;
@@ -17,7 +25,11 @@ use cli::{BotActions, BotCli};
 use tokio::signal;
 use utils::{project_dirs, AddType};
 
+/// File name of the setup contact QR code.
 const INVITE_QR: &str = "1o1_invite_qr.png";
+
+/// Bot version printed in response to the `version` command line command
+/// and sent back in response to the `/version` chat message.
 const VERSION: &str = include_file_str!("VERSION");
 
 #[tokio::main]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,3 +1,6 @@
+//! Chat messages sent by the bot.
+
+/// Text message sent by the bot together with the `store.xdc`.
 pub fn store_message() -> &'static str {
     r#"Welcome to the webxdc store!"#
 }

--- a/src/request_handlers/mod.rs
+++ b/src/request_handlers/mod.rs
@@ -15,6 +15,7 @@ use ts_rs::TS;
 
 pub mod store;
 
+/// `manifest.toml` structure.
 #[derive(Deserialize)]
 pub struct WebxdcManifest {
     /// Webxdc application identifier.
@@ -36,22 +37,45 @@ pub struct WebxdcManifest {
     pub date: String,
 }
 
+/// Information about a single application in the store index.
 #[derive(TS, Deserialize, Serialize, Clone, Debug, Default, PartialEq)]
 #[ts(export)]
 #[ts(export_to = "frontend/src/bindings/")]
 pub struct AppInfo {
+    #[allow(clippy::missing_docs_in_private_items)]
     #[serde(skip)]
     pub id: RecordId,
+
+    /// Application ID, e.g. `webxdc-poll`.
     pub app_id: String,
+
+    /// Release tag, e.g. `v2.2.0`.
     pub tag_name: String,
+
+    /// Date as a timestamp in seconds.
     pub date: i64,
+
+    /// Application name, e.g. `Checklist`.
     pub name: String,
+
+    /// Source code URL, e.g. `https://codeberg.org/webxdc/checklist`.
     pub source_code_url: String,
+
+    /// Application icon encoded as a data URL,
+    /// for example `data:image/png;base64,...`.
     pub image: String,
+
+    /// Human-readable application description.
     pub description: String,
+
+    /// Application size in bytes.
     pub size: i64,
+
+    /// Absolute path to the .xdc file.
     #[serde(skip)]
     pub xdc_blob_path: PathBuf,
+
+    /// True if the application has been removed.
     #[serde(skip)]
     pub removed: bool,
 }
@@ -100,6 +124,7 @@ impl AppInfo {
 /// WebXDC status update.
 #[derive(Serialize, Deserialize)]
 pub struct WebxdcStatusUpdate {
+    /// `payload` field of the WebXDC update.
     pub payload: WebxdcStatusUpdatePayload,
 }
 
@@ -109,20 +134,35 @@ pub struct WebxdcStatusUpdate {
 #[ts(export_to = "frontend/src/bindings/")]
 #[serde(tag = "type")]
 pub enum WebxdcStatusUpdatePayload {
-    // General update request.
+    /// Request sent from the frontend to the bot
+    /// when user clicks "Download"
+    /// in the dialog notifying about
+    /// the newer version of the `store.xdc`.
     UpdateWebxdc {
-        /// Old serial of the store.
+        /// Old serial of the store index.
         serial: u32,
     },
 
-    // General update response.
+    /// Response sent by the bot if the bot receives a request
+    /// to a previously sent `store.xdc` with a `tag_name`
+    /// different `tag_name` from the current one.
     Outdated {
+        /// Always true.
         critical: bool,
+
+        /// `tag_name` field from the `manifest.toml` of the actual `store.xdc`.
         tag_name: String,
     },
+
+    /// Response sent to an outdated version of `store.xdc`
+    /// when the user requested a new `store.xdc` with an `UpdateWebxdc` request.
+    ///
+    /// This response is used by the frontend to display
+    /// instructions for the user to look for an updated `store.xdc` in the chat.
     UpdateSent,
 
-    // Store WebXDC requests.
+    /// Request to update the application index
+    /// sent by the `store.xdc` frontend to the bot.
     UpdateRequest {
         /// Requested update sequence number.
         serial: u32,
@@ -130,41 +170,58 @@ pub enum WebxdcStatusUpdatePayload {
         #[serde(default)]
         apps: Vec<(String, String)>,
     },
+
+    /// Request to download the application .xdc
+    /// sent by the frontend to the bot.
     Download {
         /// ID of the requested application.
         app_id: String,
     },
 
-    // Store bot responses.
+    /// Successful response to the download request.
     DownloadOkay {
         /// app_id of the downloaded app.
         app_id: String,
+
         /// Name to be used as filename in `sendToChat`.
         name: String,
+
         /// Base64 encoded webxdc.
         data: String,
     },
+
+    /// Negative response to the download request.
     DownloadError {
+        /// Application ID of the requested app.
         app_id: String,
+
+        /// Error message.
         error: String,
     },
+
+    /// Index update response sent by the bot to the frontend.
     Update {
         /// List of new / updated app infos.
         #[ts(type = "Record<string, (Partial<AppInfo> & {app_id: string} | null)>")]
         app_infos: Value,
+
         /// The newest serial of the bot.    
         serial: u32,
+
         /// The old serial that the request was also made with.
         /// If it is a full [AppInfo] update, this will be 0.
         old_serial: u32,
+
         /// `app_id`s of apps that will receive an update.
         /// The frontend can use these to set the state to updating.
         updating: Vec<String>,
     },
+
     /// First message send to the store xdc together containing all [AppInfo]s.
     Init {
         /// List of initial AppInfos.
         app_infos: Vec<AppInfo>,
+
         /// Last serial of the store.
         serial: u32,
     },

--- a/src/request_handlers/store.rs
+++ b/src/request_handlers/store.rs
@@ -1,3 +1,5 @@
+//! Handling the WebXDC updates sent to the store frontend.
+
 use super::WebxdcStatusUpdatePayload;
 use crate::{
     bot::State,
@@ -15,6 +17,7 @@ use deltachat::{
 use log::{info, warn};
 use std::sync::Arc;
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub async fn handle_message(context: &Context, state: Arc<State>, chat_id: ChatId) -> Result<()> {
     let chat = chat::Chat::load_from_db(context, chat_id).await?;
     if let constants::Chattype::Single = chat.typ {
@@ -23,6 +26,7 @@ pub async fn handle_message(context: &Context, state: Arc<State>, chat_id: ChatI
     Ok(())
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub async fn handle_status_update(
     context: &Context,
     state: Arc<State>,
@@ -72,6 +76,7 @@ pub async fn handle_status_update(
     Ok(())
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub async fn handle_download(state: &State, app_id: String) -> WebxdcStatusUpdatePayload {
     match get_webxdc_data(state, &app_id).await {
         Ok((data, name)) => WebxdcStatusUpdatePayload::DownloadOkay { data, name, app_id },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,10 +30,12 @@ use crate::{
     request_handlers::{AppInfo, WebxdcManifest, WebxdcStatusUpdatePayload},
 };
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub(crate) fn project_dirs() -> Result<ProjectDirs> {
     ProjectDirs::from("", "", "XDC Store").context("cannot determine home directory")
 }
 
+/// Configures the bot account according to the environment variables `addr` and `mail_pw`.
 pub async fn configure_from_env(ctx: &Context) -> Result<()> {
     let addr = env::var("addr").context("Missing environment variable addr")?;
     ctx.set_config(Config::Addr, Some(&addr)).await?;
@@ -47,6 +49,7 @@ pub async fn configure_from_env(ctx: &Context) -> Result<()> {
     Ok(())
 }
 
+/// Unpacks the assets built into the bot binary into the configuration directory.
 pub(crate) fn unpack_assets() -> Result<()> {
     std::fs::create_dir_all(project_dirs()?.config_dir())?;
 
@@ -107,6 +110,7 @@ pub async fn update_store(
     Ok(())
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 pub fn to_hashmap<T: Serialize + for<'a> Deserialize<'a>>(
     a: T,
 ) -> serde_json::Result<HashMap<String, Value>> {
@@ -196,6 +200,7 @@ pub async fn send_newest_updates(
     Ok(())
 }
 
+/// Reads the given ZIP file entry into a string.
 pub async fn read_string(reader: &ZipFileReader, index: usize) -> Result<String> {
     let mut entry = reader.reader_with_entry(index).await?;
     let mut data = String::new();
@@ -203,6 +208,7 @@ pub async fn read_string(reader: &ZipFileReader, index: usize) -> Result<String>
     Ok(data)
 }
 
+/// Reads the given ZIP file entry into a byte vector.
 pub async fn read_vec(reader: &ZipFileReader, index: usize) -> Result<Vec<u8>> {
     let mut entry = reader.reader_with_entry(index).await?;
     let mut data = Vec::new();
@@ -229,6 +235,7 @@ pub async fn send_update_payload_only<T: Serialize>(
     Ok(())
 }
 
+/// Extracts and parses `manifest.toml` from the .xdc ZIP archive.
 pub async fn get_webxdc_manifest(reader: &ZipFileReader) -> Result<WebxdcManifest> {
     let entries = reader.file().entries();
     let manifest_index = entries
@@ -248,12 +255,14 @@ pub async fn get_webxdc_manifest(reader: &ZipFileReader) -> Result<WebxdcManifes
     Ok(toml::from_str(&read_string(reader, manifest_index).await?)?)
 }
 
+/// Returns the `tag_name` field from the `manifest.toml` of the given `.xdc` file.
 pub async fn get_webxdc_tag_name(file: impl AsRef<Path>) -> Result<String> {
     let reader = ZipFileReader::new(file).await?;
     let manifest = get_webxdc_manifest(&reader).await?;
     Ok(manifest.tag_name)
 }
 
+#[allow(clippy::missing_docs_in_private_items)]
 #[derive(Debug, PartialEq)]
 pub enum AddType {
     /// Add a new app_info
@@ -310,10 +319,12 @@ pub async fn maybe_upgrade_xdc(
     Ok(add_type)
 }
 
+/// Returns the file path to the store frontend .xdc file.
 pub fn get_store_xdc_path() -> Result<PathBuf> {
     Ok(project_dirs()?.config_dir().to_path_buf().join("store.xdc"))
 }
 
+/// Returns the file path to the store avatar.
 pub fn get_icon_path() -> Result<PathBuf> {
     Ok(project_dirs()?.config_dir().to_path_buf().join("icon.png"))
 }


### PR DESCRIPTION
Most useful part of this is the documentation for webxdc requests and responses, without the comments it was not easy to guess what `UpdateSent` message is for etc.