### PR TITLE
Fix the log message about frontend update

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -243,7 +243,7 @@ impl Bot {
         if store_tag_name != state.store_tag_name {
             info!(
                 "Store xdc frontend's tag_name changed from {} to {}, triggering update",
-                state.store_tag_name, store_tag_name
+                store_tag_name, state.store_tag_name
             );
 
             // Only try to upgrade version, if the webxdc event is _not_ an update response already


### PR DESCRIPTION
state.store_tag_name is the latest version known to the bot, while store_tag_name is the old version of a particular instance sent in the past.